### PR TITLE
US04 - Ajout des favoris avec icône cœur, tri et filtre via modales

### DIFF
--- a/client/src/components/Cart.tsx
+++ b/client/src/components/Cart.tsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react'
-import { CartContext } from '../contexts/CartContext'
+import CartContext  from '../contexts/CartContext'
 import '../styles/Cart.css' 
 
 function Cart() {

--- a/client/src/components/FilterModal.tsx
+++ b/client/src/components/FilterModal.tsx
@@ -1,0 +1,48 @@
+import '../styles/SortFilterModal.css' // on réutilise les styles existants
+
+type Props = {
+  onClose: () => void
+  selectedCategory: string
+  onCategoryChange: (category: string) => void
+}
+
+function FilterModal({ onClose, selectedCategory, onCategoryChange }: Props) {
+  const categories = ['Tropicale', 'Succulente', 'Déco'] // tu peux modifier selon ta BDD
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-blur" />
+      <div className="modal-container">
+        <button type="button" className="close-btn" onClick={onClose}>✖</button>
+        <h2>Filtrer par catégorie</h2>
+        <form className="sort-options">
+          {categories.map((cat) => (
+            <label key={cat}>
+              <input
+                type="radio"
+                name="category"
+                value={cat}
+                checked={selectedCategory === cat}
+                onChange={(e) => onCategoryChange(e.target.value)}
+              />
+              {cat}
+            </label>
+          ))}
+          <label>
+            <input
+              type="radio"
+              name="category"
+              value=""
+              checked={selectedCategory === ''}
+              onChange={(e) => onCategoryChange('')}
+            />
+            Toutes les catégories
+          </label>
+        </form>
+        <button type="button" className="validate-btn" onClick={onClose}>Valider</button>
+      </div>
+    </div>
+  )
+}
+
+export default FilterModal

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -1,6 +1,6 @@
 import '../styles/Footer.css'
 import { FaFacebook, FaPinterest, FaInstagram} from 'react-icons/fa'
-
+import { Link } from 'react-router-dom'
 function Footer() {
     return (
         <footer className="footer">
@@ -16,10 +16,10 @@ function Footer() {
                 <p className="footer-copy">© 2025 Mon Oasis - Tous droits réservé</p>
                 </div>
                 <div className="footer-right">
-                    <a href="#">Qui sommes-nous ?</a>
-                    <a href="#">Mentions légales</a>
-                    <a href="#">Politique de confidentialité</a>
-                    <a href="#">Contact</a>
+                    <Link to="/a-propos">Qui sommes-nous ?</Link>
+                    <Link to="/mentions-legales">Mentions légales</Link>
+                    <Link to="/confidentialite">Politique de confidentialité</Link>
+                    <Link to ="/contact">Contact</Link>
                     <p className="footer-contact">monoasis@projet.com</p>
                     <p className="footer-contact">+33 1 25 30 45 44</p>
                     </div>

--- a/client/src/components/PlantGallery.tsx
+++ b/client/src/components/PlantGallery.tsx
@@ -1,5 +1,10 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useContext } from 'react'
 import { Link } from 'react-router-dom'
+import { FaHeart } from 'react-icons/fa'
+import { BiFilter, BiSortAlt2 } from 'react-icons/bi'
+import FavoriteContext from '../contexts/FavoriteContext'
+import SortFilterModal from './SortFilterModal'
+import FilterModal from './FilterModal' // 👈 nouveau fichier à créer
 import '../styles/PlantGallery.css'
 
 type Plant = {
@@ -13,25 +18,31 @@ type Plant = {
 
 function PlantGallery() {
   const [plants, setPlants] = useState<Plant[]>([])
-  const [visibleCount, setVisibleCount] = useState(12) 
+  const [visibleCount, setVisibleCount] = useState(12)
   const [columns, setColumns] = useState(3)
+  const { favorites, toggleFavorite } = useContext(FavoriteContext)
 
-useEffect(() => {
-  const updateColumns = () => {
-    const width = window.innerWidth
-    if (width < 768) setColumns(3)
+  const [showSortModal, setShowSortModal] = useState(false)
+  const [showFilterModal, setShowFilterModal] = useState(false)
+  const [sortOption, setSortOption] = useState<string>('default')
+  const [selectedCategory, setSelectedCategory] = useState<string>('')
+
+  useEffect(() => {
+    const updateColumns = () => {
+      const width = window.innerWidth
+      if (width < 768) setColumns(3)
       else if (width < 1024) setColumns(3)
       else setColumns(4)
-  }
-  updateColumns()
-  window.addEventListener('resize', updateColumns)
-  return () => window.removeEventListener('resize', updateColumns)
-}, [])
+    }
+    updateColumns()
+    window.addEventListener('resize', updateColumns)
+    return () => window.removeEventListener('resize', updateColumns)
+  }, [])
 
-useEffect(() => {
-  const initialCount = columns * 3
-  setVisibleCount(initialCount)
-}, [columns])
+  useEffect(() => {
+    const initialCount = columns * 3
+    setVisibleCount(initialCount)
+  }, [columns])
 
   useEffect(() => {
     fetch('http://localhost:5002/api/plants')
@@ -44,10 +55,48 @@ useEffect(() => {
     setVisibleCount((prev) => prev + columns * 3)
   }
 
+  const filteredPlants = selectedCategory
+    ? plants.filter((plant) => plant.category === selectedCategory)
+    : plants
+
+  const sortedPlants = [...filteredPlants].sort((a, b) => {
+    if (sortOption === 'asc') return a.price - b.price
+    if (sortOption === 'desc') return b.price - a.price
+    return 0
+  })
+
   return (
     <>
+      <div className="gallery-actions">
+  <button type="button" className="filter-icon-label" onClick={() => setShowFilterModal(true)}>
+    <BiFilter size={20} />
+    <span className="filter-text">Filtrer</span>
+  </button>
+
+  <button type="button" className="sort-icon-label" onClick={() => setShowSortModal(true)}>
+    <span className="sort-text">Trier par</span>
+    <BiSortAlt2 size={22} />
+  </button>
+</div>
+
+      {showSortModal && (
+        <SortFilterModal
+          onClose={() => setShowSortModal(false)}
+          onSortChange={setSortOption}
+          selectedSort={sortOption}
+        />
+      )}
+
+      {showFilterModal && (
+        <FilterModal
+          onClose={() => setShowFilterModal(false)}
+          selectedCategory={selectedCategory}
+          onCategoryChange={setSelectedCategory}
+        />
+      )}
+
       <section className='plant-gallery'>
-        {plants.slice(0, visibleCount).map((plant) => (
+        {sortedPlants.slice(0, visibleCount).map((plant) => (
           <div key={plant.id} className='plant-card'>
             <Link to={`/plant/${plant.id}`}>
               <div className='plant-image-wrapper'>
@@ -58,6 +107,16 @@ useEffect(() => {
                 <div className='overlay'>Voir l'article</div>
               </div>
             </Link>
+            <button
+              type="button"
+              className='favorite-btn'
+              onClick={() => toggleFavorite(plant.id)}
+            >
+              <FaHeart
+                style={{ color: favorites.includes(plant.id) ? '#3A9D23' : '#FFFFFF' }}
+                size={21}
+              />
+            </button>
             <div className='plant-info'>
               <h3>{plant.name}</h3>
               <div className='stars'>★★★★★</div>
@@ -67,7 +126,7 @@ useEffect(() => {
         ))}
       </section>
 
-      {visibleCount < plants.length && (
+      {visibleCount < sortedPlants.length && (
         <div className='show-more-container'>
           <button type="button" className='show-more-btn' onClick={handleShowMore}>
             Voir plus

--- a/client/src/components/SortFilterModal.tsx
+++ b/client/src/components/SortFilterModal.tsx
@@ -1,0 +1,44 @@
+import '../styles/SortFilterModal.css'
+
+type Props = {
+  onClose: () => void
+  onSortChange: (value: string) => void
+  selectedSort: string
+}
+
+function SortFilterModal({ onClose, onSortChange, selectedSort }: Props) {
+  return (
+    <div className="modal-overlay">
+    <div className="modal-blur" />
+      <div className="modal-container">
+        <button type="button" className="close-btn" onClick={onClose}>✖</button>
+        <h2>Trier par</h2>
+        <form className="sort-options">
+          <label>
+            <input
+              type="radio"
+              name="sort"
+              value="asc"
+              checked={selectedSort === 'asc'}
+              onChange={(e) => onSortChange(e.target.value)}
+            />
+            Prix croissant
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="sort"
+              value="desc"
+              checked={selectedSort === 'desc'}
+              onChange={(e) => onSortChange(e.target.value)}
+            />
+            Prix décroissant
+          </label>
+        </form>
+        <button type="button" className="validate-btn" onClick={onClose}>Valider</button>
+      </div>
+    </div>
+  )
+}
+
+export default SortFilterModal

--- a/client/src/components/WelcomeBanner.tsx
+++ b/client/src/components/WelcomeBanner.tsx
@@ -3,7 +3,7 @@ import { FaSearch, FaUser, FaShoppingCart } from 'react-icons/fa'
 import { useNavigate, Link } from 'react-router-dom'
 import logo from '../assets/logo.png'
 import '../styles/WelcomeBanner.css'
-import { CartContext } from '../contexts/CartContext'
+import CartContext from '../contexts/CartContext'
 
 function WelcomeBanner() {
   const [showBanner, setShowBanner] = useState(true)

--- a/client/src/contexts/CartContext.tsx
+++ b/client/src/contexts/CartContext.tsx
@@ -1,5 +1,4 @@
-import { createContext, useEffect, useState } from 'react'
-import type { ReactNode } from 'react'
+import { createContext } from 'react'
 
 export type CartItem = {
   id: number
@@ -17,7 +16,7 @@ type CartContextType = {
   clearCart: () => void
 }
 
-export const CartContext = createContext<CartContextType>({
+const CartContext = createContext<CartContextType>({
   cart: [],
   totalItems: 0,
   addToCart: () => {},
@@ -25,55 +24,4 @@ export const CartContext = createContext<CartContextType>({
   clearCart: () => {},
 })
 
-type Props = {
-  children: ReactNode
-}
-
-export function CartProvider({ children }: Props) {
-  const [cart, setCart] = useState<CartItem[]>([])
-
-  // Charger depuis localStorage au démarrage
-  useEffect(() => {
-    const storedCart = localStorage.getItem('cart')
-    if (storedCart) {
-      setCart(JSON.parse(storedCart))
-    }
-  }, [])
-
-  // Enregistrer dans localStorage à chaque changement
-  useEffect(() => {
-    localStorage.setItem('cart', JSON.stringify(cart))
-  }, [cart])
-
-  const addToCart = (newItem: CartItem) => {
-    setCart((prevCart) => {
-      const existingItem = prevCart.find(item => item.id === newItem.id)
-      if (existingItem) {
-        return prevCart.map(item =>
-          item.id === newItem.id
-            ? { ...item, quantity: item.quantity + newItem.quantity }
-            : item
-        )
-      }
-      return [...prevCart, newItem]
-    })
-  }
-
-  const removeFromCart = (id: number) => {
-    setCart((prevCart) => prevCart.filter(item => item.id !== id))
-  }
-
-  const clearCart = () => {
-    setCart([])
-  }
-
-  const totalItems = cart.reduce((acc, item) => acc + item.quantity, 0)
-
-  return (
-    <CartContext.Provider
-      value={{ cart, totalItems, addToCart, removeFromCart, clearCart }}
-    >
-      {children}
-    </CartContext.Provider>
-  )
-}
+export default CartContext

--- a/client/src/contexts/CartProvider.tsx
+++ b/client/src/contexts/CartProvider.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react'
+import type { ReactNode } from 'react'
+import type { CartItem } from './CartContext'
+import CartContext from './CartContext'
+type Props = {
+  children: ReactNode
+}
+
+export function CartProvider({ children }: Props) {
+  const [cart, setCart] = useState<CartItem[]>([])
+
+  useEffect(() => {
+    const storedCart = localStorage.getItem('cart')
+    if (storedCart) {
+      setCart(JSON.parse(storedCart))
+    }
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem('cart', JSON.stringify(cart))
+  }, [cart])
+
+  const addToCart = (newItem: CartItem) => {
+    setCart((prevCart) => {
+      const existingItem = prevCart.find(item => item.id === newItem.id)
+      if (existingItem) {
+        return prevCart.map(item =>
+          item.id === newItem.id
+            ? { ...item, quantity: item.quantity + newItem.quantity }
+            : item
+        )
+      }
+      return [...prevCart, newItem]
+    })
+  }
+
+  const removeFromCart = (id: number) => {
+    setCart((prevCart) => prevCart.filter(item => item.id !== id))
+  }
+
+  const clearCart = () => {
+    setCart([])
+  }
+
+  const totalItems = cart.reduce((acc, item) => acc + item.quantity, 0)
+
+  return (
+    <CartContext.Provider
+      value={{ cart, totalItems, addToCart, removeFromCart, clearCart }}
+    >
+      {children}
+    </CartContext.Provider>
+  )
+}

--- a/client/src/contexts/FavoriteContext.tsx
+++ b/client/src/contexts/FavoriteContext.tsx
@@ -1,0 +1,13 @@
+import { createContext } from 'react'
+
+type FavoriteContextType = {
+  favorites: number[]
+  toggleFavorite: (plantId: number) => void
+}
+
+const FavoriteContext = createContext<FavoriteContextType>({
+  favorites: [],
+  toggleFavorite: () => {},
+})
+
+export default FavoriteContext

--- a/client/src/contexts/FavoriteProvider.tsx
+++ b/client/src/contexts/FavoriteProvider.tsx
@@ -1,0 +1,32 @@
+import { useState, useEffect } from 'react'
+import type { ReactNode } from 'react'
+import FavoriteContext from './FavoriteContext'
+
+type Props = {
+  children: ReactNode
+}
+
+export function FavoriteProvider({ children }: Props) {
+  const [favorites, setFavorites] = useState<number[]>(() => {
+    const stored = localStorage.getItem('favorites')
+    return stored ? JSON.parse(stored) : []
+  })
+
+  useEffect(() => {
+    localStorage.setItem('favorites', JSON.stringify(favorites))
+  }, [favorites])
+
+  const toggleFavorite = (plantId: number) => {
+    setFavorites((prev) =>
+      prev.includes(plantId)
+        ? prev.filter((id) => id !== plantId)
+        : [...prev, plantId]
+    )
+  }
+
+  return (
+    <FavoriteContext.Provider value={{ favorites, toggleFavorite }}>
+      {children}
+    </FavoriteContext.Provider>
+  )
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -5,7 +5,8 @@ import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap-icons/font/bootstrap-icons.css';
-import { CartProvider } from './contexts/CartContext'
+import { CartProvider } from './contexts/CartProvider'
+import { FavoriteProvider } from './contexts/FavoriteProvider'
 
 const rootElement = document.getElementById('root');
 if (rootElement) {
@@ -13,7 +14,9 @@ if (rootElement) {
     <React.StrictMode>
       <BrowserRouter>
       <CartProvider>
+        <FavoriteProvider>
         <App />
+      </FavoriteProvider>
         </CartProvider>
       </BrowserRouter>
     </React.StrictMode>

--- a/client/src/pages/PlantDetail.tsx
+++ b/client/src/pages/PlantDetail.tsx
@@ -1,7 +1,7 @@
 // src/pages/PlantDetail.tsx
 import { useParams } from 'react-router-dom'
 import { useEffect, useState, useContext } from 'react'
-import { CartContext } from '../contexts/CartContext'
+import CartContext from '../contexts/CartContext'
 
 
 type Plant = {

--- a/client/src/styles/SortFilterModal.css
+++ b/client/src/styles/SortFilterModal.css
@@ -1,0 +1,89 @@
+.modal-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  
+  .modal-blur {
+    position: absolute;
+    inset: 0;
+    background-color: rgba(0, 0, 0, 0.3);
+    backdrop-filter: blur(5px);
+    -webkit-backdrop-filter: blur(5px);
+    z-index: 1;
+  }
+  @keyframes slideUp {
+    from {
+      transform: translateY(150vh);
+      opacity: 0;
+    }
+    to {
+      transform: translateY(0);
+      opacity: 1;
+    }
+  }
+
+  .modal-container {
+    position: relative;
+    z-index: 2;
+    background-color: #ffffff;
+    padding: 2rem 1.5rem;
+    border-radius: 16px;
+    width: 90%;
+    max-width: 380px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+    text-align: center;
+    animation: slideUp 0.4s ease-out forwards;
+  }
+
+  .close-btn {
+    position: absolute;
+    top: 12px;
+    right: 16px;
+    background: none;
+    border: none;
+    font-size: 1.2rem;
+    cursor: pointer;
+    color: #555;
+  }
+  
+  .modal-content h2 {
+    font-size: 1.3rem;
+    margin-bottom: 1.5rem;
+    color: #22543d;
+  }
+  
+  .sort-options {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    text-align: left;
+  }
+  
+  .sort-options label {
+    font-size: 1rem;
+    color: #333;
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+  }
+  
+  .validate-btn {
+    background-color: #22543d;
+    color: white;
+    padding: 0.7rem 2rem;
+    border: none;
+    border-radius: 25px;
+    font-size: 1rem;
+    cursor: pointer;
+    margin-top: 2rem;
+    transition: background-color 0.3s ease;
+  }
+  
+  .validate-btn:hover {
+    background-color: #1a3c2f;
+  }
+  

--- a/client/src/styles/plantGallery.css
+++ b/client/src/styles/plantGallery.css
@@ -7,6 +7,7 @@
 }
 
 .plant-card {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -100,7 +101,56 @@
   background-color: #1e3a2d;
 }
 
+.favorite-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  z-index: 10;
+  filter: drop-shadow(0 1px 2px rgba(0,0,0,0.6)); 
+}
+.gallery-actions {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1rem 2rem 0 2rem;
+  margin-bottom: -1rem;
+  gap: 2rem;
+  margin-bottom: -1rem;
+}
 
+.sort-icon {
+  color: #22543d;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.sort-icon:hover {
+  transform: scale(1.1);
+}
+.filter-icon-label,
+.sort-icon-label {
+  all: unset; 
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #22543d;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.filter-icon-label:hover,
+.sort-icon-label:hover {
+  transform: scale(1.05);
+}
+
+.filter-text,
+.sort-text {
+  font-size: 1rem;
+  font-weight: 500;
+}
 @media (min-width: 1024px) {
   .plant-gallery {
     grid-template-columns: repeat(4, 1fr);
@@ -126,4 +176,10 @@
     margin-top: -2.0rem;
     margin-bottom: 1rem;
   }
+  .favorite-btn {
+    top: 6px;
+    right: 6px;
+    font-size: 18px;
+  }
+
 }


### PR DESCRIPTION
Description
Possibilité de mettre une plante en favori via une icône cœur.  
Ajout également de fonctionnalités de **tri** par prix et de **filtrage** par catégorie via des modales accessibles et responsives.
- ◦ Icône cœur qui devient verte si cliquée  
- ◦ Favoris sauvegardés localement  
- ◦ Les favoris persistent après rechargement de la page  
- ◦ Le cœur s'affiche correctement même après un tri ou un filtre  
- ◦ Interface responsive (mobile / tablette)  
- ◦ Accès clavier possible pour le tri et le filtre

Tâches techniques
- ◦ Ajout d'un `state` `favorites` dans un contexte global (`FavoriteContext`)  
- ◦ Création d’un **bouton cœur** sur chaque carte plante (`FaHeart`)  
- ◦ Mise en place de la fonction `toggleFavorite` pour ajouter/retirer un favori  
- ◦ Sauvegarde des favoris dans `localStorage` (avec récupération au chargement)  
- ◦ Ajout d’une **modale de tri** par prix (ascendant / descendant)  
- ◦ Ajout d’une **modale de filtre** par catégorie  
- ◦ Affichage des icônes **Filtrer** et **Trier par** au-dessus de la galerie  
- ◦ Cœur blanc par défaut avec `drop-shadow` pour garantir la visibilité sur image sombre  
- ◦ Amélioration de l’accessibilité (`button` au lieu de `div`, navigation clavier activée)  
- ◦ Le tri et le filtre n’altèrent pas le fonctionnement des favoris
