### PR TITLE
[FEAT] US05 - Ajout de la recherche de plante par nom via la barre de…

### DIFF
--- a/client/src/components/PlantGallery.tsx
+++ b/client/src/components/PlantGallery.tsx
@@ -1,83 +1,96 @@
-import { useEffect, useState, useContext } from 'react'
-import { Link } from 'react-router-dom'
-import { FaHeart } from 'react-icons/fa'
-import { BiFilter, BiSortAlt2 } from 'react-icons/bi'
-import FavoriteContext from '../contexts/FavoriteContext'
-import SortFilterModal from './SortFilterModal'
-import FilterModal from './FilterModal' // 👈 nouveau fichier à créer
-import '../styles/PlantGallery.css'
+import { useEffect, useState, useContext } from "react";
+import { Link } from "react-router-dom";
+import { FaHeart } from "react-icons/fa";
+import { BiFilter, BiSortAlt2 } from "react-icons/bi";
+import FavoriteContext from "../contexts/FavoriteContext";
+import SortFilterModal from "./SortFilterModal";
+import FilterModal from "./FilterModal"; // 👈 nouveau fichier à créer
+import SearchContext from "../contexts/SearchContext";
+import "../styles/PlantGallery.css";
 
 type Plant = {
-  id: number
-  name: string
-  image: string
-  price: number
-  description: string
-  category: string
-}
+  id: number;
+  name: string;
+  image: string;
+  price: number;
+  description: string;
+  category: string;
+};
 
 function PlantGallery() {
-  const [plants, setPlants] = useState<Plant[]>([])
-  const [visibleCount, setVisibleCount] = useState(12)
-  const [columns, setColumns] = useState(3)
-  const { favorites, toggleFavorite } = useContext(FavoriteContext)
-
-  const [showSortModal, setShowSortModal] = useState(false)
-  const [showFilterModal, setShowFilterModal] = useState(false)
-  const [sortOption, setSortOption] = useState<string>('default')
-  const [selectedCategory, setSelectedCategory] = useState<string>('')
+  const [plants, setPlants] = useState<Plant[]>([]);
+  const [visibleCount, setVisibleCount] = useState(12);
+  const [columns, setColumns] = useState(3);
+  const { favorites, toggleFavorite } = useContext(FavoriteContext);
+  const { searchTerm } = useContext(SearchContext);
+  const [showSortModal, setShowSortModal] = useState(false);
+  const [showFilterModal, setShowFilterModal] = useState(false);
+  const [sortOption, setSortOption] = useState<string>("default");
+  const [selectedCategory, setSelectedCategory] = useState<string>("");
 
   useEffect(() => {
     const updateColumns = () => {
-      const width = window.innerWidth
-      if (width < 768) setColumns(3)
-      else if (width < 1024) setColumns(3)
-      else setColumns(4)
-    }
-    updateColumns()
-    window.addEventListener('resize', updateColumns)
-    return () => window.removeEventListener('resize', updateColumns)
-  }, [])
+      const width = window.innerWidth;
+      if (width < 768) setColumns(3);
+      else if (width < 1024) setColumns(3);
+      else setColumns(4);
+    };
+    updateColumns();
+    window.addEventListener("resize", updateColumns);
+    return () => window.removeEventListener("resize", updateColumns);
+  }, []);
 
   useEffect(() => {
-    const initialCount = columns * 3
-    setVisibleCount(initialCount)
-  }, [columns])
+    const initialCount = columns * 3;
+    setVisibleCount(initialCount);
+  }, [columns]);
 
   useEffect(() => {
-    fetch('http://localhost:5002/api/plants')
+    fetch("http://localhost:5002/api/plants")
       .then((res) => res.json())
       .then((data) => setPlants(data))
-      .catch((error) => console.error('Erreur fetch:', error))
-  }, [])
+      .catch((error) => console.error("Erreur fetch:", error));
+  }, []);
 
   const handleShowMore = () => {
-    setVisibleCount((prev) => prev + columns * 3)
-  }
+    setVisibleCount((prev) => prev + columns * 3);
+  };
 
   const filteredPlants = selectedCategory
     ? plants.filter((plant) => plant.category === selectedCategory)
-    : plants
+    : plants;
 
-  const sortedPlants = [...filteredPlants].sort((a, b) => {
-    if (sortOption === 'asc') return a.price - b.price
-    if (sortOption === 'desc') return b.price - a.price
-    return 0
-  })
+  const searchedPlants = filteredPlants.filter((plant) =>
+    plant.name.toLowerCase().includes(searchTerm.toLowerCase()),
+  );
+
+  const sortedPlants = [...searchedPlants].sort((a, b) => {
+    if (sortOption === "asc") return a.price - b.price;
+    if (sortOption === "desc") return b.price - a.price;
+    return 0;
+  });
 
   return (
     <>
       <div className="gallery-actions">
-  <button type="button" className="filter-icon-label" onClick={() => setShowFilterModal(true)}>
-    <BiFilter size={20} />
-    <span className="filter-text">Filtrer</span>
-  </button>
+        <button
+          type="button"
+          className="filter-icon-label"
+          onClick={() => setShowFilterModal(true)}
+        >
+          <BiFilter size={20} />
+          <span className="filter-text">Filtrer</span>
+        </button>
 
-  <button type="button" className="sort-icon-label" onClick={() => setShowSortModal(true)}>
-    <span className="sort-text">Trier par</span>
-    <BiSortAlt2 size={22} />
-  </button>
-</div>
+        <button
+          type="button"
+          className="sort-icon-label"
+          onClick={() => setShowSortModal(true)}
+        >
+          <span className="sort-text">Trier par</span>
+          <BiSortAlt2 size={22} />
+        </button>
+      </div>
 
       {showSortModal && (
         <SortFilterModal
@@ -95,46 +108,56 @@ function PlantGallery() {
         />
       )}
 
-      <section className='plant-gallery'>
+      {sortedPlants.length === 0 ? (
+        <p className="no-results-message">Aucune plante trouvée.</p>
+      ) : (
+
+      <section className="plant-gallery">
         {sortedPlants.slice(0, visibleCount).map((plant) => (
-          <div key={plant.id} className='plant-card'>
+          <div key={plant.id} className="plant-card">
             <Link to={`/plant/${plant.id}`}>
-              <div className='plant-image-wrapper'>
+              <div className="plant-image-wrapper">
                 <img
                   src={`http://localhost:5002/images/${plant.image}`}
                   alt={plant.name}
                 />
-                <div className='overlay'>Voir l'article</div>
+                <div className="overlay">Voir l'article</div>
               </div>
             </Link>
             <button
               type="button"
-              className='favorite-btn'
+              className="favorite-btn"
               onClick={() => toggleFavorite(plant.id)}
             >
               <FaHeart
-                style={{ color: favorites.includes(plant.id) ? '#3A9D23' : '#FFFFFF' }}
+                style={{
+                  color: favorites.includes(plant.id) ? "#3A9D23" : "#FFFFFF",
+                }}
                 size={21}
               />
             </button>
-            <div className='plant-info'>
+            <div className="plant-info">
               <h3>{plant.name}</h3>
-              <div className='stars'>★★★★★</div>
+              <div className="stars">★★★★★</div>
               <p>{Number(plant.price).toFixed(2)} €</p>
             </div>
           </div>
         ))}
       </section>
-
+      )}
       {visibleCount < sortedPlants.length && (
-        <div className='show-more-container'>
-          <button type="button" className='show-more-btn' onClick={handleShowMore}>
+        <div className="show-more-container">
+          <button
+            type="button"
+            className="show-more-btn"
+            onClick={handleShowMore}
+          >
             Voir plus
           </button>
         </div>
       )}
     </>
-  )
+  );
 }
 
-export default PlantGallery
+export default PlantGallery;

--- a/client/src/components/WelcomeBanner.tsx
+++ b/client/src/components/WelcomeBanner.tsx
@@ -1,31 +1,33 @@
-import { useEffect, useRef, useState, useContext } from 'react'
-import { FaSearch, FaUser, FaShoppingCart } from 'react-icons/fa'
-import { useNavigate, Link } from 'react-router-dom'
-import logo from '../assets/logo.png'
-import '../styles/WelcomeBanner.css'
-import CartContext from '../contexts/CartContext'
+import { useEffect, useRef, useState, useContext } from "react";
+import { FaSearch, FaUser, FaShoppingCart } from "react-icons/fa";
+import { useNavigate, Link } from "react-router-dom";
+import logo from "../assets/logo.png";
+import "../styles/WelcomeBanner.css";
+import CartContext from "../contexts/CartContext";
+import SearchContext  from "../contexts/SearchContext";
 
 function WelcomeBanner() {
-  const [showBanner, setShowBanner] = useState(true)
-  const [showSearchBar, setShowSearchBar] = useState(false)
-  const searchRef = useRef<HTMLDivElement>(null)
-  const inputRef = useRef<HTMLInputElement>(null)
-  const { totalItems } = useContext(CartContext)
-  const navigate = useNavigate()
+  const [showBanner, setShowBanner] = useState(true);
+  const [showSearchBar, setShowSearchBar] = useState(false);
+  const searchRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { totalItems } = useContext(CartContext);
+  const { setSearchTerm } = useContext(SearchContext);
+  const navigate = useNavigate();
 
   // Masquer la bannière au scroll
   useEffect(() => {
     const handleScroll = () => {
       if (window.scrollY > 50) {
-        setShowBanner(false)
+        setShowBanner(false);
       } else {
-        setShowBanner(true)
+        setShowBanner(true);
       }
-    }
+    };
 
-    window.addEventListener('scroll', handleScroll)
-    return () => window.removeEventListener('scroll', handleScroll)
-  }, [])
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
 
   // Fermer la barre de recherche si on clique en dehors
   useEffect(() => {
@@ -34,22 +36,22 @@ function WelcomeBanner() {
         searchRef.current &&
         !searchRef.current.contains(event.target as Node)
       ) {
-        setShowSearchBar(false)
+        setShowSearchBar(false);
       }
-    }
+    };
 
     if (showSearchBar) {
-      document.addEventListener('mousedown', handleClickOutside)
+      document.addEventListener("mousedown", handleClickOutside);
     }
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [showSearchBar])
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [showSearchBar]);
 
   // Focus sur la barre de recherche
   useEffect(() => {
     if (showSearchBar && inputRef.current) {
-      inputRef.current.focus()
+      inputRef.current.focus();
     }
-  }, [showSearchBar])
+  }, [showSearchBar]);
 
   return (
     <header className="welcome-header py-3 shadow-sm sticky-top">
@@ -69,28 +71,29 @@ function WelcomeBanner() {
               type="text"
               className="form-control"
               placeholder="Rechercher une plante..."
+              onChange={(e) => setSearchTerm(e.target.value)}
             />
           </div>
         ) : (
           <div className="d-flex gap-3 fs-5 text-success">
             <FaSearch
               onClick={() => setShowSearchBar(true)}
-              style={{ cursor: 'pointer' }}
+              style={{ cursor: "pointer" }}
               title="Rechercher"
             />
 
-<button
-  type="button"
-  className="icon-button"
-  onClick={() => navigate('/cart')}
->
-  <FaShoppingCart title="Panier" />
-  {totalItems > 0 && (
-    <span className="cart-count">{totalItems}</span>
-  )}
-</button>
+            <button
+              type="button"
+              className="icon-button"
+              onClick={() => navigate("/cart")}
+            >
+              <FaShoppingCart title="Panier" />
+              {totalItems > 0 && (
+                <span className="cart-count">{totalItems}</span>
+              )}
+            </button>
 
-            <FaUser style={{ cursor: 'pointer' }} title="Connexion" />
+            <FaUser style={{ cursor: "pointer" }} title="Connexion" />
           </div>
         )}
       </div>
@@ -98,16 +101,18 @@ function WelcomeBanner() {
       {showBanner && (
         <div className="text-center mt-4">
           <h1 className="big-title text-success text-center">
-            Bienvenue sur<br /> Mon Oasis
+            Bienvenue sur
+            <br /> Mon Oasis
           </h1>
           <p className="text-muted banner-subtitle">
-            Explorer notre sélection de plantes<br className="mobile-line-break" />
+            Explorer notre sélection de plantes
+            <br className="mobile-line-break" />
             pour créer votre coin de verdure
           </p>
         </div>
       )}
     </header>
-  )
+  );
 }
 
-export default WelcomeBanner
+export default WelcomeBanner;

--- a/client/src/contexts/SearchContext.tsx
+++ b/client/src/contexts/SearchContext.tsx
@@ -1,0 +1,24 @@
+import { createContext, useState } from 'react'
+import type { ReactNode } from 'react'
+
+type SearchContextType = {
+  searchTerm: string
+  setSearchTerm: (term: string) => void
+}
+
+const SearchContext = createContext<SearchContextType>({
+  searchTerm: '',
+  setSearchTerm: () => {},
+})
+
+export function SearchProvider({ children }: { children: ReactNode }) {
+  const [searchTerm, setSearchTerm] = useState('')
+
+  return (
+    <SearchContext.Provider value={{ searchTerm, setSearchTerm }}>
+      {children}
+    </SearchContext.Provider>
+  )
+}
+
+export default SearchContext

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -7,6 +7,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap-icons/font/bootstrap-icons.css';
 import { CartProvider } from './contexts/CartProvider'
 import { FavoriteProvider } from './contexts/FavoriteProvider'
+import { SearchProvider } from './contexts/SearchContext'
 
 const rootElement = document.getElementById('root');
 if (rootElement) {
@@ -15,7 +16,9 @@ if (rootElement) {
       <BrowserRouter>
       <CartProvider>
         <FavoriteProvider>
+          <SearchProvider>
         <App />
+        </SearchProvider>
       </FavoriteProvider>
         </CartProvider>
       </BrowserRouter>

--- a/client/src/styles/plantGallery.css
+++ b/client/src/styles/plantGallery.css
@@ -151,6 +151,17 @@
   font-size: 1rem;
   font-weight: 500;
 }
+
+.no-results-message {
+  text-align: center;
+  color: #6c757d; /* gris doux */
+  font-size: 1.1rem;
+  padding: 2rem 1rem;
+  min-height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 @media (min-width: 1024px) {
   .plant-gallery {
     grid-template-columns: repeat(4, 1fr);


### PR DESCRIPTION
Ajout d’une barre de recherche permettant à l’utilisateur de rechercher une plante par son nom. Lorsqu’un mot est saisi, la galerie des plantes s’actualise dynamiquement pour n’afficher que celles correspondant au terme recherché.

✔️ Critères d’acceptation :
-L’icône recherche permet d’afficher une barre de recherche.
-La barre est automatiquement focus à l’ouverture.
-Les résultats sont filtrés dynamiquement en fonction du nom saisi.
-Le message "Aucune plante trouvée." s’affiche si aucun résultat ne correspond.